### PR TITLE
Compiler options - use c++11 flag

### DIFF
--- a/cmake/CompilerOptionsFuncs.cmake
+++ b/cmake/CompilerOptionsFuncs.cmake
@@ -61,7 +61,11 @@ endmacro ()
 
 macro (embxx_add_cpp11_support)
     if (CMAKE_COMPILER_IS_GNUCC)
-        embxx_add_cxx_flags("--std=c++0x")
+        if (COMPILER_SUPPORTS_CXX11)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+        else (COMPILER_SUPPORTS_CXX0X)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+        endif()
     endif ()
 endmacro ()
 

--- a/cmake/CompilerOptionsFuncs.cmake
+++ b/cmake/CompilerOptionsFuncs.cmake
@@ -44,7 +44,7 @@ macro (embxx_add_asm_c_cxx_flags)
 endmacro ()
 
 macro (embxx_set_default_compiler_options)
-    if (UNIX)
+    if (CMAKE_COMPILER_IS_GNUCC)
         set (extra_c_cxx_flags 
             "-Wall"
             "-Wextra"
@@ -60,26 +60,26 @@ macro (embxx_set_default_compiler_options)
 endmacro ()
 
 macro (embxx_add_cpp11_support)
-    if (UNIX)
+    if (CMAKE_COMPILER_IS_GNUCC)
         embxx_add_cxx_flags("--std=c++0x")
     endif ()
 endmacro ()
 
 macro (embxx_disable_exceptions)
-    if (UNIX)
+    if (CMAKE_COMPILER_IS_GNUCC)
         embxx_add_cxx_flags("-fno-exceptions -fno-unwind-tables")
     endif ()
 endmacro ()
 
 macro (embxx_disable_rtti)
-    if (UNIX)
+    if (CMAKE_COMPILER_IS_GNUCC)
         embxx_add_cxx_flags("-fno-rtti")
     endif ()
 endmacro ()
 
 macro (embxx_disable_stdlib)
     add_definitions(-DNOSTDLIB)
-    if (UNIX)
+    if (CMAKE_COMPILER_IS_GNUCC)
         embxx_add_c_cxx_flags("-nostdlib")
     endif ()
 endmacro ()


### PR DESCRIPTION
Readme states a user should use >=v4.7, which has already c++11 support (reference https://gcc.gnu.org/gcc-4.7/cxx0x_status.html). Thus I think we could switch to c++11.

As assurance, we can change this to:

```
if (COMPILER_SUPPORTS_CXX11)
	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
elseif (COMPILER_SUPPORTS_CXX0X)
	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
else()
```