### PR TITLE
clang - removing some compiler errors for clang

### DIFF
--- a/embxx/io/WriteQueue.h
+++ b/embxx/io/WriteQueue.h
@@ -305,7 +305,7 @@ template <typename TDriver,
 void WriteQueue<TDriver, TSize, THandler>::cancelAllWrites()
 {
     if (queue_.isEmpty()) {
-        return false;
+        return;
     }
 
     return driver_.cancelWrite();

--- a/embxx/io/access.h
+++ b/embxx/io/access.h
@@ -236,7 +236,10 @@ typename std::decay<T>::type signExtCommon(T value, std::size_t size)
     return value;
 }
 
-template <typename T, std::size_t TSize, typename TByteType>
+// http://lists.llvm.org/pipermail/cfe-dev/2013-November/033677.html
+template<size_t N> struct Size { static constexpr size_t value = N; };
+
+template <typename T, typename TSize, typename TByteType>
 class SignExt
 {
 public:
@@ -250,12 +253,12 @@ public:
 
         auto castedValue = static_cast<UnsignedValueType>(value);
         return static_cast<ValueType>(
-            signExtCommon<UnsignedByteType>(castedValue, TSize));
+        signExtCommon<UnsignedByteType>(castedValue, TSize::value));
     }
 };
-
+    
 template <typename T, typename TByteType>
-class SignExt<T, sizeof(typename std::decay<T>::type), TByteType>
+class SignExt<T, Size<sizeof(typename std::decay<T>::type)>, TByteType>
 {
 public:
     static typename std::decay<T>::type value(T value)
@@ -651,7 +654,7 @@ struct Reader
                 THelper<TEndian, IsRandomAccess>::template read<OptimisedValueType>(TSize, iter));
 
         if (std::is_signed<ValueType>::value) {
-            retval = details::SignExt<decltype(retval), TSize, ByteType>::value(retval);
+            retval = details::SignExt<decltype(retval), Size<TSize>, ByteType>::value(retval);
         }
         return static_cast<T>(retval);
     }

--- a/embxx/util/Allocators.h
+++ b/embxx/util/Allocators.h
@@ -280,7 +280,7 @@ public:
         static_assert(IsInTuple<TObj, TTuple>::Value,
                     "TObj must be included in TTuple");
 
-        return allocator_.alloc<TObj>(std::forward<TArgs>(args)...);
+        return allocator_.template alloc<TObj>(std::forward<TArgs>(args)...);
     }
 
 private:

--- a/embxx/util/EventLoop.h
+++ b/embxx/util/EventLoop.h
@@ -181,8 +181,9 @@ private:
         virtual std::size_t getSize() const;
         virtual void exec();
 
-        static const std::size_t Size =
-            ((sizeof(TaskBound<typename std::decay<TTask>::type>) - 1) / sizeof(Task)) + 1;
+        static constexpr std::size_t Size() {
+            return ((sizeof(TaskBound<typename std::decay<TTask>::type>) - 1) / sizeof(Task)) + 1;
+        }
 
     private:
         TTask task_;
@@ -416,7 +417,7 @@ template <std::size_t TSize,
 template <typename TTask>
 std::size_t EventLoop<TSize, TLock, TCond>::TaskBound<TTask>::getSize() const
 {
-    return Size;
+    return Size();
 }
 
 template <std::size_t TSize,
@@ -440,7 +441,7 @@ bool EventLoop<TSize, TLock, TCond>::postNoLock(TTask&& task)
     static_assert(std::alignment_of<Task>::value == std::alignment_of<TaskBoundType>::value,
         "Alignment of TaskBound must be same as alignment of Task");
 
-    static const std::size_t requiredQueueSize = TaskBoundType::Size;
+    static const std::size_t requiredQueueSize = TaskBoundType::Size();
 
     bool wasEmpty = queue_.isEmpty();
 


### PR DESCRIPTION
Hi Alex,

here is some initial work on getting embxx to compile with `clang-3.7` and `clang++-3.7`.
Errors are removed, but there are still some warnings left, that one should investigate.

So no need, for this to be merged this just yet. You can just leave this pull-request open, for people to base their further work on, regarding issue #7 