### PR TITLE
fix, to allow custom installations of boost

### DIFF
--- a/module/comms/test/CMakeLists.txt
+++ b/module/comms/test/CMakeLists.txt
@@ -114,6 +114,13 @@ function (test_checksum_layer)
     set (name "${COMPONENT_NAME}.${test_suite_name}Test")
 
     set (runner "${test_suite_name}TestRunner.cpp")
+
+    if (NOT Boost_INCLUDE_DIRS)
+      find_package(Boost REQUIRED)
+    endif()
+    if(Boost_FOUND)
+      include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+    endif()
     
     set (link)
 

--- a/module/device/test/CMakeLists.txt
+++ b/module/device/test/CMakeLists.txt
@@ -14,9 +14,16 @@ function (test_device_op_queue)
     set (name "${COMPONENT_NAME}.${test_suite_name}Test")
 
     set (runner "${test_suite_name}TestRunner.cpp")
+
+    if ((NOT Boost_INCLUDE_DIRS) OR (NOT Boost_SYSTEM_LIBRARY))
+      find_package(Boost COMPONENTS system REQUIRED)
+    endif()
+    if(Boost_FOUND)
+      include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+    endif()
     
     set (link
-        "boost_system"
+        "${Boost_SYSTEM_LIBRARY}"
         "pthread")
 
     CXXTEST_ADD_TEST (${name} ${runner} ${tests} ${extra_sources})
@@ -37,8 +44,15 @@ function (test_id_device_char_adapter)
 
     set (runner "${test_suite_name}TestRunner.cpp")
     
+    if ((NOT Boost_INCLUDE_DIRS) OR (NOT Boost_SYSTEM_LIBRARY))
+      find_package(Boost COMPONENTS system REQUIRED)
+    endif()
+    if(Boost_FOUND)
+      include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+    endif()
+
     set (link
-        "boost_system"
+        "${Boost_SYSTEM_LIBRARY}"
         "pthread")
 
     CXXTEST_ADD_TEST (${name} ${runner} ${tests} ${extra_sources})

--- a/module/driver/test/CMakeLists.txt
+++ b/module/driver/test/CMakeLists.txt
@@ -15,8 +15,15 @@ function (test_timer_mgr)
 
     set (runner "${test_suite_name}TestRunner.cpp")
     
+    if ((NOT Boost_INCLUDE_DIRS) OR (NOT Boost_SYSTEM_LIBRARY))
+      find_package(Boost COMPONENTS system REQUIRED)
+    endif()
+    if(Boost_FOUND)
+      include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+    endif()
+
     set (link
-        "boost_system"
+        "${Boost_SYSTEM_LIBRARY}"
         "pthread")
 
     CXXTEST_ADD_TEST (${name} ${runner} ${tests} ${extra_sources})
@@ -57,8 +64,15 @@ function (test_character)
 
     set (runner "${test_suite_name}TestRunner.cpp")
     
+    if ((NOT Boost_INCLUDE_DIRS) OR (NOT Boost_SYSTEM_LIBRARY))
+      find_package(Boost COMPONENTS system REQUIRED)
+    endif()
+    if(Boost_FOUND)
+      include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+    endif()
+
     set (link
-        "boost_system"
+        "${Boost_SYSTEM_LIBRARY}"
         "pthread")
 
     CXXTEST_ADD_TEST (${name} ${runner} ${tests} ${extra_sources})
@@ -78,9 +92,16 @@ function (test_gpio)
     set (name "${COMPONENT_NAME}.${test_suite_name}Test")
 
     set (runner "${test_suite_name}TestRunner.cpp")
-    
+
+    if ((NOT Boost_INCLUDE_DIRS) OR (NOT Boost_SYSTEM_LIBRARY))
+      find_package(Boost COMPONENTS system REQUIRED)
+    endif()
+    if(Boost_FOUND)
+      include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+    endif()
+
     set (link
-        "boost_system"
+        "${Boost_SYSTEM_LIBRARY}"
         "pthread")
 
     CXXTEST_ADD_TEST (${name} ${runner} ${tests} ${extra_sources})

--- a/module/io/test/CMakeLists.txt
+++ b/module/io/test/CMakeLists.txt
@@ -54,9 +54,16 @@ function (test_write_queue)
     set (name "${COMPONENT_NAME}.${test_suite_name}Test")
 
     set (runner "${test_suite_name}TestRunner.cpp")
-    
+
+    if ((NOT Boost_INCLUDE_DIRS) OR (NOT Boost_SYSTEM_LIBRARY))
+      find_package(Boost COMPONENTS system REQUIRED)
+    endif()
+    if(Boost_FOUND)
+      include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+    endif()
+
     set (link
-        "boost_system"
+        "${Boost_SYSTEM_LIBRARY}"
         "pthread")
 
     CXXTEST_ADD_TEST (${name} ${runner} ${tests} ${extra_sources})
@@ -77,8 +84,15 @@ function (test_out_stream_buf)
 
     set (runner "${test_suite_name}TestRunner.cpp")
     
+    if ((NOT Boost_INCLUDE_DIRS) OR (NOT Boost_SYSTEM_LIBRARY))
+      find_package(Boost COMPONENTS system REQUIRED)
+    endif()
+    if(Boost_FOUND)
+      include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+    endif()
+
     set (link
-        "boost_system"
+        "${Boost_SYSTEM_LIBRARY}"
         "pthread")
 
     CXXTEST_ADD_TEST (${name} ${runner} ${tests} ${extra_sources})
@@ -99,8 +113,15 @@ function (test_out_stream)
 
     set (runner "${test_suite_name}TestRunner.cpp")
     
+    if ((NOT Boost_INCLUDE_DIRS) OR (NOT Boost_SYSTEM_LIBRARY))
+      find_package(Boost COMPONENTS system REQUIRED)
+    endif()
+    if(Boost_FOUND)
+      include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+    endif()
+
     set (link
-        "boost_system"
+        "${Boost_SYSTEM_LIBRARY}"
         "pthread")
 
     CXXTEST_ADD_TEST (${name} ${runner} ${tests} ${extra_sources})
@@ -121,8 +142,15 @@ function (test_in_stream_buf)
 
     set (runner "${test_suite_name}TestRunner.cpp")
     
+    if ((NOT Boost_INCLUDE_DIRS) OR (NOT Boost_SYSTEM_LIBRARY))
+      find_package(Boost COMPONENTS system REQUIRED)
+    endif()
+    if(Boost_FOUND)
+      include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+    endif()
+
     set (link
-        "boost_system"
+        "${Boost_SYSTEM_LIBRARY}"
         "pthread")
 
     CXXTEST_ADD_TEST (${name} ${runner} ${tests} ${extra_sources})


### PR DESCRIPTION
Now works for custom boost installations (i.e. when boost is NOT gotten from the system path)

Call `cmake`, with the flag `BOOST_ROOT`. 
Example:
```bash
cmake -DBOOST_ROOT=/my/path/to/boost ..
```
where
`/my/path/to/boost/include` and `/my/path/to/boost/lib` exist.

.
.
OR call `cmake` with the flags `BOOST_INCLUDEDIR`, `BOOST_LIBRARYDIR`. 
Example:
```bash
cmake -DBOOST_INCLUDEDIR=/my/path/to/boost/include -DBOOST_LIBRARYDIR=/my/path/to/boost/lib
```
Ref: https://cmake.org/cmake/help/latest/module/FindBoost.html